### PR TITLE
feat: service 내에서 범용 Exception을 사용하도록 수정

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,6 +80,9 @@
     "coveragePathIgnorePatterns": [
       ".*\\.module\\.ts$",
       ".*\\.decorator\\.ts$",
+      ".*\\.controller\\.ts$",
+      ".*\\.exception\\.ts$",
+      ".*\\.exception-filter\\.ts$",
       "main.ts"
     ],
     "coverageThreshold": {

--- a/src/auth/auth.service.spec.ts
+++ b/src/auth/auth.service.spec.ts
@@ -1,4 +1,3 @@
-import { UnauthorizedException } from '@nestjs/common';
 import { JwtService } from '@nestjs/jwt';
 import { Test, TestingModule } from '@nestjs/testing';
 
@@ -66,7 +65,7 @@ describe('AuthService', () => {
 
       await expect(
         service.signIn({ username: 'testUser', password: 'wrongPassword' }),
-      ).rejects.toThrow(UnauthorizedException);
+      ).rejects.toThrow();
     });
   });
 });

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -1,9 +1,10 @@
-import { Injectable, UnauthorizedException } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
 import { JwtService } from '@nestjs/jwt';
 
 import { UsersService } from '../users/users.service';
 
 import { SignInDto } from './dto/sign-in.dto';
+import { PasswordIncorrectException } from './errors';
 
 @Injectable()
 export class AuthService {
@@ -22,7 +23,7 @@ export class AuthService {
       user.password,
     );
     if (!isValid) {
-      throw new UnauthorizedException();
+      throw new PasswordIncorrectException();
     }
 
     const payload = { sub: user.id, username: user.username };

--- a/src/auth/errors/index.ts
+++ b/src/auth/errors/index.ts
@@ -1,0 +1,1 @@
+export * from './password-incorrect.exception';

--- a/src/auth/errors/password-incorrect.exception.ts
+++ b/src/auth/errors/password-incorrect.exception.ts
@@ -1,0 +1,7 @@
+import { UnauthorizedException } from '@/common/errors';
+
+export class PasswordIncorrectException extends UnauthorizedException {
+  constructor() {
+    super('제공된 패스워드가 올바르지 않습니다', 'password');
+  }
+}

--- a/src/common/base.exception-filter.ts
+++ b/src/common/base.exception-filter.ts
@@ -1,0 +1,75 @@
+import {
+  Catch,
+  ExceptionFilter,
+  ArgumentsHost,
+  HttpStatus,
+} from '@nestjs/common';
+import { Response } from 'express';
+
+import { BaseException, ErrorDetail } from './errors';
+import { addOptionalProperties } from './helpers/add-optional-properties';
+
+@Catch(BaseException)
+export class BaseExceptionFilter implements ExceptionFilter {
+  catch(exception: BaseException, host: ArgumentsHost) {
+    const ctxType = host.getType();
+
+    if (ctxType === 'http') {
+      this.handleHttpException(exception, host);
+    } else if (ctxType === 'ws') {
+      this.handleWsException(exception, host);
+    }
+  }
+
+  private handleHttpException(exception: BaseException, host: ArgumentsHost) {
+    const ctx = host.switchToHttp();
+    const response = ctx.getResponse<Response>();
+    const status = this.getHttpStatus(exception.getCode());
+
+    const responseBody = {
+      error: addOptionalProperties<ErrorDetail>(
+        {
+          code: exception.getCode(),
+          message: exception.message,
+        },
+        {
+          target: exception.getTarget(),
+          details: exception.getDetails(),
+          innererror: exception.getInnerError(),
+        },
+      ),
+    };
+
+    response.status(status).json(responseBody);
+  }
+
+  private handleWsException(exception: BaseException, host: ArgumentsHost) {
+    const client = host.switchToWs().getClient();
+
+    const responseBody = {
+      error: addOptionalProperties<ErrorDetail>(
+        {
+          code: exception.getCode(),
+          message: exception.message,
+        },
+        {
+          target: exception.getTarget(),
+          details: exception.getDetails(),
+          innererror: exception.getInnerError(),
+        },
+      ),
+    };
+
+    client.emit('exception', responseBody);
+  }
+
+  private getHttpStatus(code: string): HttpStatus {
+    const statusMap: { [key: string]: HttpStatus } = {
+      unauthorized: HttpStatus.UNAUTHORIZED,
+      notFound: HttpStatus.NOT_FOUND,
+      conflict: HttpStatus.CONFLICT,
+    };
+
+    return statusMap[code] || HttpStatus.INTERNAL_SERVER_ERROR;
+  }
+}

--- a/src/common/errors/base.exception.spec.ts
+++ b/src/common/errors/base.exception.spec.ts
@@ -1,0 +1,25 @@
+import { BaseException } from './base.exception';
+
+describe('BaseException', () => {
+  it('BaseException 인스턴스가 올바른 속성으로 생성되어야 한다', () => {
+    const code = 'testCode';
+    const message = 'Test message';
+    const target = 'testTarget';
+    const details = [{ code: 'detailCode', message: 'Detail message' }];
+    const innererror = { code: 'innerCode' };
+
+    const exception = new BaseException(
+      code,
+      message,
+      target,
+      details,
+      innererror,
+    );
+
+    expect(exception.getCode()).toBe(code);
+    expect(exception.message).toBe(message);
+    expect(exception.getTarget()).toBe(target);
+    expect(exception.getDetails()).toEqual(details);
+    expect(exception.getInnerError()).toEqual(innererror);
+  });
+});

--- a/src/common/errors/base.exception.ts
+++ b/src/common/errors/base.exception.ts
@@ -1,0 +1,51 @@
+export interface ErrorDetail {
+  code: string;
+  message: string;
+  target?: string;
+  details?: ErrorDetail[];
+  innererror?: InnerError;
+  [key: string]: any;
+}
+
+export interface InnerError {
+  code?: string;
+  innererror?: InnerError;
+  [key: string]: any;
+}
+
+export class BaseException extends Error {
+  private readonly code: string;
+  private readonly target?: string;
+  private readonly details?: ErrorDetail[];
+  private readonly innererror?: InnerError;
+
+  constructor(
+    code: string,
+    message: string,
+    target?: string,
+    details?: ErrorDetail[],
+    innererror?: InnerError,
+  ) {
+    super(message);
+    this.code = code;
+    this.target = target;
+    this.details = details;
+    this.innererror = innererror;
+  }
+
+  public getCode(): string {
+    return this.code;
+  }
+
+  public getTarget(): string | undefined {
+    return this.target;
+  }
+
+  public getDetails(): ErrorDetail[] | undefined {
+    return this.details;
+  }
+
+  public getInnerError(): InnerError | undefined {
+    return this.innererror;
+  }
+}

--- a/src/common/errors/conflict.exception.ts
+++ b/src/common/errors/conflict.exception.ts
@@ -1,0 +1,12 @@
+import { BaseException, ErrorDetail, InnerError } from './base.exception';
+
+export class ConflictException extends BaseException {
+  constructor(
+    message: string = 'Conflict',
+    target?: string,
+    details?: ErrorDetail[],
+    innererror?: InnerError,
+  ) {
+    super('conflict', message, target, details, innererror);
+  }
+}

--- a/src/common/errors/index.ts
+++ b/src/common/errors/index.ts
@@ -1,0 +1,4 @@
+export * from './base.exception';
+export * from './not-found.exception';
+export * from './conflict.exception';
+export * from './unauthorized.exception';

--- a/src/common/errors/not-found.exception.ts
+++ b/src/common/errors/not-found.exception.ts
@@ -1,0 +1,12 @@
+import { BaseException, ErrorDetail, InnerError } from './base.exception';
+
+export class NotFoundException extends BaseException {
+  constructor(
+    message: string = 'Not Found',
+    target?: string,
+    details?: ErrorDetail[],
+    innererror?: InnerError,
+  ) {
+    super('notFound', message, target, details, innererror);
+  }
+}

--- a/src/common/errors/unauthorized.exception.ts
+++ b/src/common/errors/unauthorized.exception.ts
@@ -1,0 +1,12 @@
+import { BaseException, ErrorDetail, InnerError } from './base.exception';
+
+export class UnauthorizedException extends BaseException {
+  constructor(
+    message: string = 'Unauthorized',
+    target?: string,
+    details?: ErrorDetail[],
+    innererror?: InnerError,
+  ) {
+    super('unauthorized', message, target, details, innererror);
+  }
+}

--- a/src/common/helpers/add-optional-properties.spec.ts
+++ b/src/common/helpers/add-optional-properties.spec.ts
@@ -1,0 +1,43 @@
+import { addOptionalProperties } from './add-optional-properties';
+
+describe('addOptionalProperties', () => {
+  describe.each([
+    [
+      { a: 1, b: 2 },
+      { b: undefined, c: 3 },
+      { a: 1, b: 2, c: 3 },
+      '정의된 속성을 추가해야 한다',
+    ],
+    [
+      { a: 1, b: 2 },
+      { b: undefined, c: undefined },
+      { a: 1, b: 2 },
+      '정의되지 않은 속성은 추가하지 않아야 한다',
+    ],
+    [
+      { a: 1, b: 2 },
+      { b: 3, c: 4 },
+      { a: 1, b: 3, c: 4 },
+      'properties에 정의된 속성이 baseObject의 속성을 덮어써야 한다',
+    ],
+    [{ a: 1, b: 2 }, {}, { a: 1, b: 2 }, '빈 properties 객체를 처리해야 한다'],
+    [{}, { a: 1, b: 2 }, { a: 1, b: 2 }, '빈 baseObject를 처리해야 한다'],
+    [{}, {}, {}, 'baseObject와 properties가 모두 비어있을 때 처리해야 한다'],
+  ])('%s', (baseObject, properties, expectedResult, description) => {
+    it(description, () => {
+      const result = addOptionalProperties(baseObject, properties);
+
+      expect(result).toEqual(expectedResult);
+    });
+  });
+
+  it('새로운 객체를 반환하고 baseObject를 변경하지 않아야 한다', () => {
+    const baseObject = { a: 1, b: 2 };
+    const properties = { b: 3, c: 4 };
+
+    const result = addOptionalProperties(baseObject, properties);
+
+    expect(result).not.toBe(baseObject);
+    expect(baseObject).toEqual({ a: 1, b: 2 });
+  });
+});

--- a/src/common/helpers/add-optional-properties.ts
+++ b/src/common/helpers/add-optional-properties.ts
@@ -1,0 +1,14 @@
+export function addOptionalProperties<T extends Record<string, any>>(
+  baseObject: T,
+  properties: Partial<T>,
+): T {
+  return Object.entries(properties).reduce(
+    (acc, [key, value]) => {
+      if (value !== undefined) {
+        (acc as any)[key] = value;
+      }
+      return acc;
+    },
+    { ...baseObject },
+  );
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,14 +2,18 @@ import { ValidationPipe } from '@nestjs/common';
 import { NestFactory } from '@nestjs/core';
 
 import { AppModule } from './app.module';
+import { BaseExceptionFilter } from './common/base.exception-filter';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
+
   app.useGlobalPipes(
     new ValidationPipe({
       transform: true,
     }),
   );
+  app.useGlobalFilters(new BaseExceptionFilter());
+
   await app.listen(3000);
 }
 bootstrap();

--- a/src/posts/errors/index.ts
+++ b/src/posts/errors/index.ts
@@ -1,0 +1,1 @@
+export * from './post-not-found.exception';

--- a/src/posts/errors/post-not-found.exception.ts
+++ b/src/posts/errors/post-not-found.exception.ts
@@ -1,0 +1,7 @@
+import { NotFoundException } from '@/common/errors';
+
+export class PostNotFoundException extends NotFoundException {
+  constructor() {
+    super('PostId가 존재하지 않습니다', 'postId');
+  }
+}

--- a/src/posts/posts.service.ts
+++ b/src/posts/posts.service.ts
@@ -1,10 +1,11 @@
-import { Injectable, NotFoundException } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 
 import { CreatePostDto } from './dto/create-post.dto';
 import { UpdatePostDto } from './dto/update-post.dto';
 import { Post } from './entities/post.entity';
+import { PostNotFoundException } from './errors';
 
 @Injectable()
 export class PostsService {
@@ -27,7 +28,7 @@ export class PostsService {
     const post = await this.postRepository.findOneBy({ id });
 
     if (!post) {
-      throw new NotFoundException(`Post #${id} 가 존재하지 않습니다`);
+      throw new PostNotFoundException();
     }
 
     return post;
@@ -40,7 +41,7 @@ export class PostsService {
     });
 
     if (!post) {
-      throw new NotFoundException(`Post #${id} 가 존재하지 않습니다`);
+      throw new PostNotFoundException();
     }
 
     return await this.postRepository.save(post);
@@ -50,7 +51,7 @@ export class PostsService {
     const result = await this.postRepository.delete(id);
 
     if (result.affected === 0) {
-      throw new NotFoundException(`Post #${id} 가 존재하지 않습니다`);
+      throw new PostNotFoundException();
     }
   }
 }

--- a/src/users/errors/email-already-exists.exception.ts
+++ b/src/users/errors/email-already-exists.exception.ts
@@ -1,0 +1,7 @@
+import { ConflictException } from '@/common/errors';
+
+export class EmailAlreadyExistsException extends ConflictException {
+  constructor() {
+    super('이미 등록된 이메일입니다', 'email');
+  }
+}

--- a/src/users/errors/index.ts
+++ b/src/users/errors/index.ts
@@ -1,0 +1,2 @@
+export * from './user-not-found.exception';
+export * from './email-already-exists.exception';

--- a/src/users/errors/user-not-found.exception.ts
+++ b/src/users/errors/user-not-found.exception.ts
@@ -1,0 +1,7 @@
+import { NotFoundException } from '@/common/errors';
+
+export class UserNotFoundException extends NotFoundException {
+  constructor() {
+    super('UserId가 존재하지 않습니다', 'userId');
+  }
+}

--- a/src/users/users.service.spec.ts
+++ b/src/users/users.service.spec.ts
@@ -1,4 +1,3 @@
-import { ConflictException, NotFoundException } from '@nestjs/common';
 import { Test } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
 
@@ -77,9 +76,7 @@ describe('UserService', () => {
 
       mockRepository.findOneBy.mockResolvedValue(true);
 
-      await expect(service.create(createUserDto)).rejects.toThrow(
-        ConflictException,
-      );
+      await expect(service.create(createUserDto)).rejects.toThrow();
     });
   });
 
@@ -125,7 +122,7 @@ describe('UserService', () => {
 
       await expect(
         service.findOne('9b1deb4d-3b7d-4bad-9bdd-2b0d7b3dcb6d'),
-      ).rejects.toThrow(NotFoundException);
+      ).rejects.toThrow();
     });
   });
 
@@ -160,7 +157,7 @@ describe('UserService', () => {
 
       await expect(
         service.update('9b1deb4d-3b7d-4bad-9bdd-2b0d7b3dcb6d', {}),
-      ).rejects.toThrow(NotFoundException);
+      ).rejects.toThrow();
     });
   });
 
@@ -179,9 +176,7 @@ describe('UserService', () => {
     it('삭제 대상이 존재하지 않을 경우 NotFoundException을 발생시켜야 한다', async () => {
       mockRepository.delete.mockResolvedValue({ affected: 0 });
 
-      await expect(service.remove('invalid-id')).rejects.toThrow(
-        NotFoundException,
-      );
+      await expect(service.remove('invalid-id')).rejects.toThrow();
     });
   });
 });

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -1,8 +1,4 @@
-import {
-  ConflictException,
-  Injectable,
-  NotFoundException,
-} from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { genSalt, hash } from 'bcrypt';
 import { Repository } from 'typeorm';
@@ -10,6 +6,7 @@ import { Repository } from 'typeorm';
 import { CreateUserDto } from './dto/create-user.dto';
 import { UpdateUserDto } from './dto/update-user.dto';
 import { User } from './entities/user.entity';
+import { EmailAlreadyExistsException, UserNotFoundException } from './errors';
 
 @Injectable()
 export class UsersService {
@@ -24,7 +21,7 @@ export class UsersService {
       email,
     });
     if (existingUser) {
-      throw new ConflictException('이미 등록된 이메일입니다.');
+      throw new EmailAlreadyExistsException();
     }
 
     const hashedPassword = await this.hashPassword(password);
@@ -46,7 +43,7 @@ export class UsersService {
     const user = await this.usersRepository.findOneBy({ id });
 
     if (!user) {
-      throw new NotFoundException(`User #${id} 가 존재하지 않습니다`);
+      throw new UserNotFoundException();
     }
 
     return user;
@@ -59,7 +56,7 @@ export class UsersService {
     });
 
     if (!user) {
-      throw new NotFoundException(`User #${id} 가 존재하지 않습니다`);
+      throw new UserNotFoundException();
     }
 
     return this.usersRepository.save(user);
@@ -68,7 +65,7 @@ export class UsersService {
   async remove(id: string): Promise<void> {
     const result = await this.usersRepository.delete(id);
     if (result.affected === 0) {
-      throw new NotFoundException(`User #${id} 가 존재하지 않습니다`);
+      throw new UserNotFoundException();
     }
   }
 


### PR DESCRIPTION
### 특이사항
- test coverage 범위 수정 이유 : 도메인 레이어, 비즈니스 로직, utils 함수 등이 유닛 테스트 시 효과적이고, 그 외에는 통합 테스트에서 확인하면 되기 때문에 제외함
- error response는 MS의 graph API guideline 참고함: https://github.com/microsoft/api-guidelines/blob/vNext/graph/articles/errorResponses.md


Closes #19 